### PR TITLE
feat: reduce max break time from 5 mins to 2 mins

### DIFF
--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -248,7 +248,7 @@ pub fn SettingsPage() -> impl IntoView {
             label="Exercise Rest Duration".to_string()
             value=rest_exercise_duration
             min=0
-            max=300
+            max=120
             step=5
             unit="s".to_string()
           />
@@ -257,7 +257,7 @@ pub fn SettingsPage() -> impl IntoView {
             label="Set Rest Duration".to_string()
             value=rest_set_duration
             min=0
-            max=300
+            max=120
             step=5
             unit="s".to_string()
           />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the settings page to limit both the exercise rest and set rest duration options to a maximum of 120 seconds, reducing the previous 300-second cap. This change streamlines the available range for rest durations, offering a more focused selection for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->