### PR TITLE
fix: use `parallel` from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -393,7 +393,7 @@
                 mkdir -p build/assets
 
                 # Build client and server WASM in parallel
-                time parallel ::: ${compile-css}/bin/compile-css ${compile-client}/bin/compile-client ${compile-server}/bin/compile-server
+                time ${pkgs.parallel}/bin/parallel ::: ${compile-css}/bin/compile-css ${compile-client}/bin/compile-client ${compile-server}/bin/compile-server
 
                 # Copy static files
                 echo "Copying static files..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the local development build process to use the Nix-provided version of the parallel command, improving reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->